### PR TITLE
Added Support For Custom Downgraded Clients (Fluster)

### DIFF
--- a/MicrosoftRBX-FPS/MicrosoftRBX-FPS/main.cpp
+++ b/MicrosoftRBX-FPS/MicrosoftRBX-FPS/main.cpp
@@ -556,7 +556,7 @@ void init()
         if (currentHWND)
         {
             std::string getTitle = getWindowTitle(currentHWND);
-            if (getTitle == "Roblox")
+            if (getTitle == "Roblox" || getTitle == "Fluster")
             {
                 robloxHWND = currentHWND;
                 system("cls");


### PR DESCRIPTION
A lot of people seem to be using a downgraded version of Roblox's "UWP" client called "Fluster". Due to the popular usage of it, it should be supported.